### PR TITLE
Support for stateless environments added to SpellCheck

### DIFF
--- a/parsivar/spell_checker.py
+++ b/parsivar/spell_checker.py
@@ -1,6 +1,6 @@
-import pickle
-import math
 import os
+import math
+from typing import Counter, Union
 
 from .normalizer import Normalizer
 from .tokenizer import Tokenizer
@@ -8,15 +8,42 @@ from .data_helper import DataHelper
 
 
 class SpellCheck:
-    def __init__(self):
+    def __init__(self,
+                 onegram_lm: Union[None, str, Counter],
+                 bigram_lm: Union[None, str, Counter]
+                 ):
+        """SpellCheck init method
+
+        Args:
+            onegram_lm (Union[None, str, Counter]): The One-gram language model,
+            based on the type of this input, the SpellCheck instance can be 
+            created using data file under __file__, or another user-provided 
+            path, or the object of the language model.
+            bigram_lm (Union[None, str, Counter]): The Bi-gram language model,
+            based on the type of this input, the SpellCheck instance can be 
+            created using data file under __file__, or another user-provided 
+            path, or the object of the language model.
+        """
         self.normalizer = Normalizer()
         self.tokenizer = Tokenizer()
         self.data_helper = DataHelper()
 
         self.dir_path = os.path.dirname(os.path.realpath(__file__)) + "/"
 
-        self.bigram_lm = self.data_helper.load_var(self.dir_path + "resource/spell/mybigram_lm.pckl")
-        self.onegram_lm = self.data_helper.load_var(self.dir_path + "resource/spell/onegram.pckl")
+        if bigram_lm is None or isinstance(bigram_lm, str):
+            bigram_file_path = bigram_lm if bigram_lm else self.dir_path + \
+                "resource/spell/mybigram_lm.pckl"
+            self.bigram_lm = self.data_helper.load_var(bigram_file_path)
+        else:
+            self.bigram_lm = bigram_lm
+
+        if onegram_lm is None or isinstance(onegram_lm, str):
+            onegram_file_path = onegram_lm if onegram_lm else self.dir_path + \
+                "resource/spell/onegram.pckl"
+            self.onegram_lm = self.data_helper.load_var(onegram_file_path)
+        else:
+            self.onegram_lm = onegram_lm
+
         self.ingroup_chars = [{'ا', 'آ', 'ع'},
                               {'ت', 'ط'},
                               {'ث', 'س', 'ص'},

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(name='parsivar',
 	  packages=['parsivar'],
-	  version='0.2.3',
+	  version='0.2.4',
 	  description='Python library for preprocessing Persian text.',
 	  author='ICT',
 	  author_email='',


### PR DESCRIPTION
This PR adds support for stateless environments in clouds, the change enables the package to get the language model files from different sources except than just the default path under package `__file__`.
In some containerized environments it's hard to get the file from an external source and write it to the file system to be used by the package, the PR helps to get the files and directly feed it into the package without writing it to disk.
